### PR TITLE
Timers entfernen und hinzufügen geändert

### DIFF
--- a/src/main/java/at/saith/twasi/cmd/TimerListCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerListCommand.java
@@ -2,6 +2,7 @@ package at.saith.twasi.cmd;
 
 import at.saith.twasi.database.TimerEntity;
 import at.saith.twasi.service.TimerService;
+import at.saith.twasi.util.TimeFormatter;
 import net.twasi.core.plugin.api.customcommands.TwasiCustomCommandEvent;
 import net.twasi.core.plugin.api.customcommands.structuredcommands.TwasiStructuredCommandEvent;
 import net.twasi.core.plugin.api.customcommands.structuredcommands.subcommands.ISubCommands;
@@ -26,7 +27,7 @@ public class TimerListCommand extends TwasiSubCommand {
             StringBuilder timersBuilder = new StringBuilder();
             for (TimerEntity timer : timers) {
                 String enabled = timer.isEnabled() ? renderer.render("timer.enabled") : renderer.render("timer.disabled");
-                timersBuilder.append(timer.getCommand() + "(" + timer.getInterval() + ", " + enabled + "), ");
+                timersBuilder.append(timer.getCommand() + "(" + TimeFormatter.formatTime(timer.getInterval()) + ", " + enabled + "), ");
             }
             if (timersBuilder.length() < 2) {
                 event.reply(renderer.render("timer.list.empty"));

--- a/src/main/java/at/saith/twasi/service/TimerService.java
+++ b/src/main/java/at/saith/twasi/service/TimerService.java
@@ -140,6 +140,9 @@ public class TimerService implements IService {
     }
 
     public TimerEntity removeTimer(TwasiInterface twasiInterface, String command) throws TimerException{
+        if (command.startsWith(TimedMessagesPlugin.COMMAND_PREFIX)) {
+            command = command.substring(TimedMessagesPlugin.COMMAND_PREFIX.length());
+        }
         User user = twasiInterface.getStreamer().getUser();
 
         TimerEntity entity = getTimerEntityForUserAndCommand(user,command);
@@ -159,9 +162,12 @@ public class TimerService implements IService {
     }
 
     public void enableTimer(TwasiInterface twasiInterface, String command, boolean enabled) throws TimerException {
+        if (command.startsWith(TimedMessagesPlugin.COMMAND_PREFIX)) {
+            command = command.substring(TimedMessagesPlugin.COMMAND_PREFIX.length());
+        }
+
         User user = twasiInterface.getStreamer().getUser();
         TimerEntity entity = getTimerEntityForUserAndCommand(user, command);
-
         entity.setEnabled(enabled);
         repository.commit(entity);
 

--- a/src/main/java/at/saith/twasi/service/TimerService.java
+++ b/src/main/java/at/saith/twasi/service/TimerService.java
@@ -103,9 +103,6 @@ public class TimerService implements IService {
     }
 
     public TimerEntity registerTimer(TwasiInterface twasiInterface, String command, int interval) throws TimerException {
-        if (command.startsWith(TimedMessagesPlugin.COMMAND_PREFIX)) {
-            command = command.substring(TimedMessagesPlugin.COMMAND_PREFIX.length());
-        }
         Streamer streamer = twasiInterface.getStreamer();
         User user = streamer.getUser();
 
@@ -147,7 +144,6 @@ public class TimerService implements IService {
         if (hasTimersEnabled(user)) {
             List<TwasiTimer> timers = getRunningTimersForUser(user);
             for (TwasiTimer timer : timers) {
-                System.out.println(timer.getCommand());
                 if (timer.getCommand().equalsIgnoreCase(command)) {
                     timer.disable();
                     timers.remove(timer);
@@ -160,13 +156,11 @@ public class TimerService implements IService {
     }
 
     public void enableTimer(TwasiInterface twasiInterface, String command, boolean enabled) throws TimerException {
-        if (command.startsWith(TimedMessagesPlugin.COMMAND_PREFIX)) {
-            command = command.substring(TimedMessagesPlugin.COMMAND_PREFIX.length());
-        }
-
         User user = twasiInterface.getStreamer().getUser();
+        
         TimerEntity entity = getTimerEntityForUserAndCommand(user, command);
         entity.setEnabled(enabled);
+
         repository.commit(entity);
 
         if (hasTimersEnabled(user)) {
@@ -195,8 +189,6 @@ public class TimerService implements IService {
         }
         for (CustomCommand cmd : commandRepository.getAllCommands(twasiInterface.getStreamer().getUser())) {
             if (cmd.getName().equalsIgnoreCase(command)) {
-                return true;
-            } else if (cmd.getName().startsWith(TimedMessagesPlugin.COMMAND_PREFIX) && cmd.getName().equalsIgnoreCase(TimedMessagesPlugin.COMMAND_PREFIX + command)) {
                 return true;
             }
         }

--- a/src/main/java/at/saith/twasi/service/TwasiTimer.java
+++ b/src/main/java/at/saith/twasi/service/TwasiTimer.java
@@ -1,6 +1,7 @@
 package at.saith.twasi.service;
 
 import at.saith.twasi.TimedMessagesPlugin;
+import at.saith.twasi.util.TimeFormatter;
 import net.twasi.core.database.models.TwitchAccount;
 import net.twasi.core.database.models.permissions.PermissionGroups;
 import net.twasi.core.interfaces.api.TwasiInterface;
@@ -57,7 +58,7 @@ public class TwasiTimer extends Timer {
     private void dispatchCommand() {
         TwitchAccount twitchAccount = twasiInterface.getStreamer().getUser().getTwitchAccount();
         twasiInterface.getDispatcher().dispatch(new TwasiMessage(
-                TimedMessagesPlugin.COMMAND_PREFIX + command,
+                command,
                 MessageType.PRIVMSG,
                 new TwitchAccount(
                         twitchAccount.getUserName(),

--- a/src/main/java/at/saith/twasi/util/TimeFormatter.java
+++ b/src/main/java/at/saith/twasi/util/TimeFormatter.java
@@ -1,23 +1,23 @@
 package at.saith.twasi.util;
 
 public class TimeFormatter {
-    public static String formatTime(long timeInSeconds){
-        int days = (int) (timeInSeconds/(60*60*24));
-        int hours = (int) (timeInSeconds/(60*60))%60;
-        int minutes = (int) (timeInSeconds/(60))%60;
-        int seconds = (int) timeInSeconds%60;
+    public static String formatTime(long timeInSeconds) {
+        int days = (int) (timeInSeconds / (60 * 60 * 24));
+        int hours = (int) (timeInSeconds / (60 * 60)) % 60;
+        int minutes = (int) (timeInSeconds / (60)) % 60;
+        int seconds = (int) timeInSeconds % 60;
         StringBuilder formattedTime = new StringBuilder();
-        if(days != 0){
-            formattedTime.append(days+"d");
+        if (days != 0) {
+            formattedTime.append(days + "d");
         }
-        if(hours != 0){
-            formattedTime.append(hours+"h");
+        if (hours != 0) {
+            formattedTime.append(hours + "h");
         }
-        if(minutes != 0){
-            formattedTime.append(minutes+"m");
+        if (minutes != 0) {
+            formattedTime.append(minutes + "m");
         }
-        if(seconds != 0){
-            formattedTime.append(seconds+"s");
+        if (seconds != 0) {
+            formattedTime.append(seconds + "s");
         }
         return formattedTime.toString();
     }

--- a/src/main/java/at/saith/twasi/util/TimeFormatter.java
+++ b/src/main/java/at/saith/twasi/util/TimeFormatter.java
@@ -1,0 +1,24 @@
+package at.saith.twasi.util;
+
+public class TimeFormatter {
+    public static String formatTime(long timeInSeconds){
+        int days = (int) (timeInSeconds/(60*60*24));
+        int hours = (int) (timeInSeconds/(60*60))%60;
+        int minutes = (int) (timeInSeconds/(60))%60;
+        int seconds = (int) timeInSeconds%60;
+        StringBuilder formattedTime = new StringBuilder();
+        if(days != 0){
+            formattedTime.append(days+"d");
+        }
+        if(hours != 0){
+            formattedTime.append(hours+"h");
+        }
+        if(minutes != 0){
+            formattedTime.append(minutes+"m");
+        }
+        if(seconds != 0){
+            formattedTime.append(seconds+"s");
+        }
+        return formattedTime.toString();
+    }
+}


### PR DESCRIPTION
Es hat ja einige Probleme beim entfernen von Timern gegeben. Das müsste mit diesem Patch eigentlich jetzt behoben sein. Also wenn es z.B. den Command !quasi gibt, würde der Befehl !timer add quasi nicht mehr funktionieren sondern nur noch !timer add !quasi.